### PR TITLE
fix annotations

### DIFF
--- a/src/Enum/Enum.php
+++ b/src/Enum/Enum.php
@@ -10,7 +10,7 @@ use ReflectionClass;
  * Class Enum
  * @package Enum
  * @author Alexander Dmitriev <alex@aadmitriev.ru>
- * @date 15.08.18
+ * @since 15.08.18
  */
 abstract class Enum implements Stringable
 {

--- a/src/Enum/EnumException.php
+++ b/src/Enum/EnumException.php
@@ -10,7 +10,7 @@ use Exception;
  * Class EnumException
  * @package Enum
  * @author Alexander Dmitriev <alex@aadmitriev.ru>
- * @date 14.10.15
+ * @since 14.10.15
  */
 class EnumException extends Exception
 {

--- a/src/Enum/MagicStaticCallEnum.php
+++ b/src/Enum/MagicStaticCallEnum.php
@@ -8,7 +8,7 @@ namespace Enum;
  * Trait MagicStaticCallEnum
  * @package Enum
  * @author Alexander Dmitriev <alex@aadmitriev.ru>
- * @date 13.12.19
+ * @since 13.12.19
  */
 trait MagicStaticCallEnum
 {


### PR DESCRIPTION
symfony throws error on deserializing
```
[Semantical Error] The annotation "@date" in class Enum\Enum was never imported. Did you maybe forget to add a "use" statement for this annotation?
```